### PR TITLE
Correct npm package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This plugin allows you to use AdonisJS with Vite as the assets bundler.
 ## Installation
 
 ```bash
-npm i -D vite-plugin-adonis
+npm i -D @adonisjs/vite-plugin-adonis
 ```
 
 ## Usage


### PR DESCRIPTION
Small fix, but the package name listed in the readme is incorrect, just needs to be updated to `@adonisjs/vite-plugin-adonis`
